### PR TITLE
[feat/avatar] rounded 이미지 컴포넌트 (#16)

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import React from "react";
+
+interface Props {
+  size: "sm" | "md" | "lg";
+  src: string;
+  alt?: string;
+}
+
+// 아바타 사이즈
+const avatarSize = {
+  sm: 50,
+  md: 150,
+  lg: 200
+};
+
+const Avatar = ({ size, src, alt }: Props) => {
+  const altText = () => {
+    switch (size) {
+      case "sm":
+        return "리뷰 유저 이미지";
+      case "md":
+        return "카테고리 이미지";
+      case "lg":
+        return "마이페이지 유저 이미지";
+      default:
+        return "이미지";
+    }
+  };
+  return (
+    <Image
+      className="rounded-full"
+      src={src}
+      width={avatarSize[size]}
+      height={avatarSize[size]}
+      priority
+      alt={alt || altText()}
+      draggable={false}
+    />
+  );
+};
+
+export default Avatar;


### PR DESCRIPTION
- size, src,를 필수로 받고 선택적으로 alt를 받을 수 있는 컴포넌트 생성
- size : sm(50px), md(150px), lg(200px)

![image](https://github.com/nbc-react-3rd-final-project-a5/clione/assets/146798554/26d88793-264f-4661-8da8-70ffccfd2948)
