### PR TITLE
[feat/layout] main 스타일지정 (#44)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
           <Header />
 
-          <main>{children}</main>
+          <main className="max-w-[1200px] mx-auto w-[90%] min-h-full">{children}</main>
           <Footer />
           <ReactQueryDevtools initialIsOpen={false} />
           <CreateModal />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,9 +5,9 @@ import footerData from "@/data/footerData.json";
 const Footer = () => {
   const { linkList, infoList } = footerData;
   return (
-    <footer>
+    <footer className="">
       <nav className="text-[#999] py-[20px] border-y-[1px] border-[#E5E5E5]">
-        <ul className="flex flex-row gap-[20px] text-[14px]">
+        <ul className="max-w-[1200px] mx-auto w-[90%] flex flex-row gap-[20px] text-[14px] ">
           {linkList.map((n) => (
             <li className="hover:underline" key={`footer__nav-${n.title}`}>
               <Link href={n.link}>{n.title}</Link>
@@ -15,7 +15,7 @@ const Footer = () => {
           ))}
         </ul>
       </nav>
-      <div className="py-[40px] flex gap-y-[40px] flex-wrap justify-between">
+      <div className="max-w-[1200px] mx-auto w-[90%] py-[40px] flex gap-y-[40px] flex-wrap justify-between">
         {/* left */}
         <div className="text-[14px] flex flex-col gap-[15px]">
           {infoList.map((n, i1) => {


### PR DESCRIPTION
-  style : main 컨테이너 width 고정하기
-  style : main 컨테이너 min height 주기
  (100%로 지정하였는데 100vh로 주면 로그인 페이지 에서  스크롤이 생겨서 입니다.)
-  style : footer 컨테이너 width 고정하기

![image](https://github.com/nbc-react-3rd-final-project-a5/clione/assets/146798554/f80e6a29-eee9-4729-8c26-e8d2328f844c)
